### PR TITLE
added health check endpoint /api/health

### DIFF
--- a/src/minitwit.web/ApiController.cs
+++ b/src/minitwit.web/ApiController.cs
@@ -212,6 +212,12 @@ public class ApiController : Controller
         }
     }
 
+    // Get endpoint for healthcheck, used by nginx reverse-proxy and rolling updates.
+    [HttpGet("/api/health")]
+    public IActionResult HealthCheck(){
+        return Ok();
+    }
+
     // POST for follow and unfolow. {Username} is the person who will follow/unfollow someone.
     [HttpPost("/api/fllws/{username}")]
     public async Task<IActionResult> PostFollow(string username, [FromBody] FollowRequest request, [FromQuery] int latest)


### PR DESCRIPTION

#### Changes Made:
- Added a new health check endpoint at `/api/health` in `APIcontroller.cs`.
- The endpoint is designed to facilitate future health checks between servers, specifically for Nginx and potential integration with Keepalive.

#### Purpose:
The health check endpoint will help ensure the reliability and availability of the services by allowing for regular checks on the API's health status